### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/dapr/dapr-grpc-service-template/.github/workflows/release-on-tag.yaml
+++ b/dapr/dapr-grpc-service-template/.github/workflows/release-on-tag.yaml
@@ -35,7 +35,7 @@ jobs:
       run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
 
     - name: Image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         VERSION: ${{ env.RELEASE_VERSION }}
       with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore